### PR TITLE
Feature/shader tap effect

### DIFF
--- a/src/Utils.Unity/Packages/jp.andantetribe.utils/.Samples/jp.andantetribe.utils.sample/Shader_Tap_Effect.meta
+++ b/src/Utils.Unity/Packages/jp.andantetribe.utils/.Samples/jp.andantetribe.utils.sample/Shader_Tap_Effect.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5e2718f1e4d327c408eb40a71a811a2d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Utils.Unity/Packages/jp.andantetribe.utils/.Samples/jp.andantetribe.utils.sample/Shader_Tap_Effect/TapEffectPanel.prefab
+++ b/src/Utils.Unity/Packages/jp.andantetribe.utils/.Samples/jp.andantetribe.utils.sample/Shader_Tap_Effect/TapEffectPanel.prefab
@@ -1,0 +1,77 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &3927312179148911310
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6058324398376559753}
+  - component: {fileID: 1229237577824242685}
+  - component: {fileID: 4464629229114000122}
+  m_Layer: 5
+  m_Name: TapEffectPanel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6058324398376559753
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3927312179148911310}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1229237577824242685
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3927312179148911310}
+  m_CullTransparentMesh: 1
+--- !u!114 &4464629229114000122
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3927312179148911310}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1

--- a/src/Utils.Unity/Packages/jp.andantetribe.utils/.Samples/jp.andantetribe.utils.sample/Shader_Tap_Effect/TapEffectPanel.prefab.meta
+++ b/src/Utils.Unity/Packages/jp.andantetribe.utils/.Samples/jp.andantetribe.utils.sample/Shader_Tap_Effect/TapEffectPanel.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 98f8d8b69b4095747b3f74e889bd99f9
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Utils.Unity/Packages/jp.andantetribe.utils/.Samples/jp.andantetribe.utils.sample/Shader_Tap_Effect/TapRippleEffect.shader
+++ b/src/Utils.Unity/Packages/jp.andantetribe.utils/.Samples/jp.andantetribe.utils.sample/Shader_Tap_Effect/TapRippleEffect.shader
@@ -1,0 +1,70 @@
+Shader "UI/TapRippleEffect"
+{
+    Properties
+    {
+        _MainTex ("Texture", 2D) = "white" {}
+        _Color ("Color", Color) = (1,1,1,1)
+        _RippleWidth ("Ripple Width", Range(0.0, 0.5)) = 0.1
+        _Progress ("Progress", Range(0.0, 1.0)) = 0.0
+    }
+    SubShader
+    {
+        Tags { "RenderType"="Transparent" "Queue"="Transparent" }
+        Blend SrcAlpha OneMinusSrcAlpha
+        ZWrite Off
+        Cull Off
+        
+        Pass
+        {
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            
+            #include "UnityCG.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float2 uv : TEXCOORD0;
+            };
+
+            struct v2f
+            {
+                float2 uv : TEXCOORD0;
+                float4 vertex : SV_POSITION;
+            };
+
+            sampler2D _MainTex;
+            float4 _Color;
+            float _RippleWidth;
+            float _Progress;
+            
+            v2f vert (appdata v)
+            {
+                v2f o;
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                o.uv = v.uv;
+                return o;
+            }
+            
+            fixed4 frag (v2f i) : SV_Target
+            {
+                float2 center = float2(0.5, 0.5);
+                float dist = distance(i.uv, center);
+                
+                float radius = _Progress * 0.5;
+                float alpha = 0;
+                
+                if (dist < radius && dist > radius - _RippleWidth)
+                {
+                    // リング内部の場合、中心からの距離に応じて透明度を計算
+                    alpha = 1.0 - (_Progress * 0.8); // プログレスに応じてフェードアウト
+                    alpha *= smoothstep(radius - _RippleWidth, radius, dist);
+                }
+                
+                return float4(_Color.rgb, alpha * _Color.a);
+            }
+            ENDCG
+        }
+    }
+}

--- a/src/Utils.Unity/Packages/jp.andantetribe.utils/.Samples/jp.andantetribe.utils.sample/Shader_Tap_Effect/TapRippleEffect.shader.meta
+++ b/src/Utils.Unity/Packages/jp.andantetribe.utils/.Samples/jp.andantetribe.utils.sample/Shader_Tap_Effect/TapRippleEffect.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 709fca08052da5943803bc4215aaed6c
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Utils.Unity/Packages/jp.andantetribe.utils/.Samples/jp.andantetribe.utils.sample/Shader_Tap_Effect/UI_TapRippleEffect.mat
+++ b/src/Utils.Unity/Packages/jp.andantetribe.utils/.Samples/jp.andantetribe.utils.sample/Shader_Tap_Effect/UI_TapRippleEffect.mat
@@ -29,6 +29,8 @@ Material:
         m_Offset: {x: 0, y: 0}
     m_Ints: []
     m_Floats:
+    - _AspectRatio: 1
+    - _MaxSize: 0.5
     - _Progress: 0
     - _RippleWidth: 0.1
     m_Colors:

--- a/src/Utils.Unity/Packages/jp.andantetribe.utils/.Samples/jp.andantetribe.utils.sample/Shader_Tap_Effect/UI_TapRippleEffect.mat
+++ b/src/Utils.Unity/Packages/jp.andantetribe.utils/.Samples/jp.andantetribe.utils.sample/Shader_Tap_Effect/UI_TapRippleEffect.mat
@@ -1,0 +1,37 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: UI_TapRippleEffect
+  m_Shader: {fileID: 4800000, guid: 709fca08052da5943803bc4215aaed6c, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _Progress: 0
+    - _RippleWidth: 0.1
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+  m_BuildTextureStacks: []
+  m_AllowLocking: 1

--- a/src/Utils.Unity/Packages/jp.andantetribe.utils/.Samples/jp.andantetribe.utils.sample/Shader_Tap_Effect/UI_TapRippleEffect.mat.meta
+++ b/src/Utils.Unity/Packages/jp.andantetribe.utils/.Samples/jp.andantetribe.utils.sample/Shader_Tap_Effect/UI_TapRippleEffect.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b5c67060edcdfae4ab2be0f44fd815a5
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Utils.Unity/Packages/jp.andantetribe.utils/Runtime/Modules/ShaderTapEffect.cs
+++ b/src/Utils.Unity/Packages/jp.andantetribe.utils/Runtime/Modules/ShaderTapEffect.cs
@@ -1,0 +1,114 @@
+﻿using UnityEngine;
+using UnityEngine.UI;
+using UnityEngine.EventSystems;
+using System.Collections;
+
+namespace AndanteTribe.Utils.Modules
+{
+    public class ShaderTapEffect : CancellationDisposable
+    {
+        protected readonly RectTransform CanvasRect;
+        protected readonly Image EffectImage;
+        protected readonly BaseInputModule CurrentInputModule;
+        protected readonly Material EffectMaterial;
+        protected readonly float Duration = 0.5f;
+
+        public ShaderTapEffect(RectTransform canvasRect, Image effectImage, Material effectMaterial,
+            BaseInputModule currentInputModule = null, float duration = 0.5f)
+        {
+            CanvasRect = canvasRect;
+            EffectImage = effectImage;
+            EffectMaterial = effectMaterial;
+            CurrentInputModule = currentInputModule ?? EventSystem.current.currentInputModule;
+            Duration = duration;
+
+            EffectImage.enabled = false;
+            EffectImage.material = new Material(EffectMaterial);
+        }
+
+        public void Start() => SubscribeOnLeftClick();
+
+        protected virtual void SubscribeOnLeftClick()
+        {
+#if ENABLE_INPUT_SYSTEM
+            var inputSystemModule = (UnityEngine.InputSystem.UI.InputSystemUIInputModule)CurrentInputModule;
+            inputSystemModule.leftClick.action.performed += OnLeftClick;
+            DisposableToken.Register(static obj =>
+            {
+                var self = (ShaderTapEffect)obj;
+                var inputSystemModule = (UnityEngine.InputSystem.UI.InputSystemUIInputModule)self.CurrentInputModule;
+                inputSystemModule.leftClick.action.performed -= self.OnLeftClick;
+            }, this);
+#else
+            CurrentInputModule.StartCoroutine(ObserveLeftClick());
+#endif
+        }
+
+#if ENABLE_INPUT_SYSTEM
+        protected virtual void OnLeftClick(UnityEngine.InputSystem.InputAction.CallbackContext _)
+        {
+            var screenPos = UnityEngine.InputSystem.Pointer.current?.position.ReadValue() ?? Vector2.zero;
+            if (screenPos == Vector2.zero)
+            {
+                return;
+            }
+
+            ShowEffect(screenPos);
+        }
+#else
+        private System.Collections.IEnumerator ObserveLeftClick()
+        {
+            while (!IsDisposed)
+            {
+                if (Input.GetMouseButtonDown(0))
+                {
+                    var screenPos = Input.mousePosition;
+                    ShowEffect(screenPos);
+                }
+
+                yield return null;
+            }
+        }
+#endif
+
+        protected void ShowEffect(in Vector2 screenPos)
+        {
+            RectTransformUtility.ScreenPointToLocalPointInRectangle(
+                CanvasRect, screenPos, null, out var localPoint);
+
+            EffectImage.rectTransform.anchoredPosition = localPoint;
+            EffectImage.enabled = true;
+
+            EffectImage.material.SetFloat("_Progress", 0);
+
+            CurrentInputModule.StartCoroutine(AnimateEffect());
+        }
+
+        private IEnumerator AnimateEffect()
+        {
+            float startTime = Time.time;
+            float progress = 0;
+
+            while (progress < 1.0f)
+            {
+                progress = (Time.time - startTime) / Duration;
+                EffectImage.material.SetFloat("_Progress", progress);
+                yield return null;
+            }
+
+            EffectImage.enabled = false;
+        }
+
+        public override void Dispose()
+        {
+            if (!IsDisposed)
+            {
+                if (EffectImage != null && EffectImage.material != null)
+                {
+                    Object.Destroy(EffectImage.material);
+                }
+            }
+            base.Dispose();
+        }
+    }
+}

--- a/src/Utils.Unity/Packages/jp.andantetribe.utils/Runtime/Modules/ShaderTapEffect.cs
+++ b/src/Utils.Unity/Packages/jp.andantetribe.utils/Runtime/Modules/ShaderTapEffect.cs
@@ -2,31 +2,63 @@
 using UnityEngine.UI;
 using UnityEngine.EventSystems;
 using System.Collections;
+using System.Collections.Generic;
 
 namespace AndanteTribe.Utils.Modules
 {
     public class ShaderTapEffect : CancellationDisposable
     {
+        // エフェクト情報を保持する構造体
+        private struct TapEffectData
+        {
+            public Vector2 Position;
+            public float StartTime;
+            public float Progress;
+            public bool IsActive;
+        }
+
         protected readonly RectTransform CanvasRect;
         protected readonly Image EffectImage;
         protected readonly BaseInputModule CurrentInputModule;
-        protected readonly Material EffectMaterial;
         protected readonly float Duration = 0.5f;
 
+        // エフェクトデータ配列（固定長）
+        private readonly TapEffectData[] _effectsData;
+        private readonly int _maxEffects;
+
+        // シェーダープロパティID
+        private static readonly int s_positionsID = Shader.PropertyToID("_TapPositions");
+        private static readonly int s_progressesID = Shader.PropertyToID("_TapProgresses");
+        private static readonly int s_countID = Shader.PropertyToID("_TapCount");
+
+        private Vector4[] _positions;
+        private float[] _progresses;
+        private Coroutine _updateCoroutine;
+
         public ShaderTapEffect(RectTransform canvasRect, Image effectImage, Material effectMaterial,
-            BaseInputModule currentInputModule = null, float duration = 0.5f)
+            BaseInputModule currentInputModule = null, float duration = 0.5f, int maxEffects = 10)
         {
             CanvasRect = canvasRect;
             EffectImage = effectImage;
-            EffectMaterial = effectMaterial;
             CurrentInputModule = currentInputModule ?? EventSystem.current.currentInputModule;
             Duration = duration;
+            _maxEffects = maxEffects;
 
-            EffectImage.enabled = false;
-            EffectImage.material = new Material(EffectMaterial);
+            // 効率化のためにエフェクトデータを初期化
+            _effectsData = new TapEffectData[_maxEffects];
+            _positions = new Vector4[_maxEffects];
+            _progresses = new float[_maxEffects];
+
+            // 1つのマテリアルインスタンスを使用
+            EffectImage.material = new Material(effectMaterial);
+            EffectImage.enabled = true;
         }
 
-        public void Start() => SubscribeOnLeftClick();
+        public void Start()
+        {
+            SubscribeOnLeftClick();
+            _updateCoroutine = CurrentInputModule.StartCoroutine(UpdateEffects());
+        }
 
         protected virtual void SubscribeOnLeftClick()
         {
@@ -38,6 +70,8 @@ namespace AndanteTribe.Utils.Modules
                 var self = (ShaderTapEffect)obj;
                 var inputSystemModule = (UnityEngine.InputSystem.UI.InputSystemUIInputModule)self.CurrentInputModule;
                 inputSystemModule.leftClick.action.performed -= self.OnLeftClick;
+                if (self._updateCoroutine != null)
+                    inputSystemModule.StopCoroutine(self._updateCoroutine);
             }, this);
 #else
             CurrentInputModule.StartCoroutine(ObserveLeftClick());
@@ -53,7 +87,7 @@ namespace AndanteTribe.Utils.Modules
                 return;
             }
 
-            ShowEffect(screenPos);
+            CreateEffect(screenPos);
         }
 #else
         private System.Collections.IEnumerator ObserveLeftClick()
@@ -63,7 +97,7 @@ namespace AndanteTribe.Utils.Modules
                 if (Input.GetMouseButtonDown(0))
                 {
                     var screenPos = Input.mousePosition;
-                    ShowEffect(screenPos);
+                    CreateEffect(screenPos);
                 }
 
                 yield return null;
@@ -71,32 +105,114 @@ namespace AndanteTribe.Utils.Modules
         }
 #endif
 
-        protected void ShowEffect(in Vector2 screenPos)
+        protected void CreateEffect(in Vector2 screenPos)
         {
             RectTransformUtility.ScreenPointToLocalPointInRectangle(
                 CanvasRect, screenPos, null, out var localPoint);
 
-            EffectImage.rectTransform.anchoredPosition = localPoint;
-            EffectImage.enabled = true;
-
-            EffectImage.material.SetFloat("_Progress", 0);
-
-            CurrentInputModule.StartCoroutine(AnimateEffect());
-        }
-
-        private IEnumerator AnimateEffect()
-        {
-            float startTime = Time.time;
-            float progress = 0;
-
-            while (progress < 1.0f)
+            // 使用可能なスロットを探す
+            int index = -1;
+            for (int i = 0; i < _maxEffects; i++)
             {
-                progress = (Time.time - startTime) / Duration;
-                EffectImage.material.SetFloat("_Progress", progress);
-                yield return null;
+                if (!_effectsData[i].IsActive)
+                {
+                    index = i;
+                    break;
+                }
             }
 
-            EffectImage.enabled = false;
+            // 空きがない場合は最も古いエフェクトを上書き
+            if (index == -1)
+            {
+                float oldestTime = float.MaxValue;
+                for (int i = 0; i < _maxEffects; i++)
+                {
+                    if (_effectsData[i].StartTime < oldestTime)
+                    {
+                        oldestTime = _effectsData[i].StartTime;
+                        index = i;
+                    }
+                }
+            }
+
+            // 新しいエフェクトデータを設定
+            _effectsData[index] = new TapEffectData
+            {
+                Position = localPoint,
+                StartTime = Time.time,
+                Progress = 0f,
+                IsActive = true
+            };
+
+            // シェーダーに渡すデータを更新
+            UpdateShaderData();
+        }
+
+        private IEnumerator UpdateEffects()
+        {
+            while (!IsDisposed)
+            {
+                bool dataChanged = false;
+                float currentTime = Time.time;
+
+                // すべてのアクティブなエフェクトを更新
+                for (int i = 0; i < _maxEffects; i++)
+                {
+                    if (_effectsData[i].IsActive)
+                    {
+                        float elapsed = currentTime - _effectsData[i].StartTime;
+                        float progress = Mathf.Clamp01(elapsed / Duration);
+
+                        _effectsData[i].Progress = progress;
+
+                        // 完了したエフェクトを非アクティブにする
+                        if (progress >= 1.0f)
+                        {
+                            var data = _effectsData[i];
+                            data.IsActive = false;
+                            _effectsData[i] = data;
+                        }
+
+                        dataChanged = true;
+                    }
+                }
+
+                // データが変更された場合のみシェーダーを更新
+                if (dataChanged)
+                {
+                    UpdateShaderData();
+                }
+
+                yield return null;
+            }
+        }
+
+        private void UpdateShaderData()
+        {
+            int activeCount = 0;
+
+            // アクティブなエフェクトの位置とプログレスを配列に設定
+            for (int i = 0; i < _maxEffects; i++)
+            {
+                if (_effectsData[i].IsActive)
+                {
+                    // シェーダーに渡すためにUV座標に変換
+                    Vector2 normalizedPos = new Vector2(
+                        (_effectsData[i].Position.x + CanvasRect.rect.width/2) / CanvasRect.rect.width,
+                        (_effectsData[i].Position.y + CanvasRect.rect.height/2) / CanvasRect.rect.height
+                    );
+                    Debug.Log(normalizedPos);
+
+                    _positions[activeCount] = new Vector4(normalizedPos.x, normalizedPos.y, 0, 0);
+                    _progresses[activeCount] = _effectsData[i].Progress;
+                    activeCount++;
+                }
+            }
+
+            // シェーダーにデータを渡す
+            EffectImage.material.SetVectorArray(s_positionsID, _positions);
+            EffectImage.material.SetFloatArray(s_progressesID, _progresses);
+            EffectImage.material.SetInt(s_countID, activeCount);
         }
 
         public override void Dispose()
@@ -106,6 +222,12 @@ namespace AndanteTribe.Utils.Modules
                 if (EffectImage != null && EffectImage.material != null)
                 {
                     Object.Destroy(EffectImage.material);
+                }
+
+                if (_updateCoroutine != null)
+                {
+                    CurrentInputModule.StopCoroutine(_updateCoroutine);
+                    _updateCoroutine = null;
                 }
             }
             base.Dispose();

--- a/src/Utils.Unity/Packages/jp.andantetribe.utils/Runtime/Modules/ShaderTapEffect.cs.meta
+++ b/src/Utils.Unity/Packages/jp.andantetribe.utils/Runtime/Modules/ShaderTapEffect.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 2eb84e76edbf458e8457c2c5f235fb6b
+timeCreated: 1749293593


### PR DESCRIPTION
# ShaderTapEffectの使い方

1.SceneにCanvas, EventSystemを作成

2.Canvas下に「TapEffectPanel」プレハブを設置
( AndanteTribe Utils Sample > Shader_Tap_Effect > TapEffectPanel )

3.以下のようなスクリプトを作成して、適当なところに設置
```
using UnityEngine;
using UnityEngine.UI;
using UnityEngine.InputSystem.UI;

public class ShaderTapEffectController : MonoBehaviour
{
    [SerializeField] private Canvas _overlayCanvas;
    [SerializeField] private Image _effectImage;
    [SerializeField] private Material _effectMaterial;
    [SerializeField] private float _effectDuration = 0.5f;
    [SerializeField] private int _maxEffects = 10;

    private AndanteTribe.Utils.Modules.ShaderTapEffect _tapEffect;

    void Start()
    {
        _tapEffect = new AndanteTribe.Utils.Modules.ShaderTapEffect(
            _overlayCanvas.GetComponent<RectTransform>(),
            _effectImage,
            _effectMaterial,
            FindAnyObjectByType<InputSystemUIInputModule>(),
            _effectDuration,
            _maxEffects);

        _tapEffect.Start();
    }

    void OnDestroy()
    {
        _tapEffect?.Dispose();
    }
}
```

4.スクリプトのインスペクター経由で
・Canvas
・設置したTapEffectPanelのImageコンポーネント
・「UI_TapRippleEffect」マテリアル
を設定
( AndanteTribe Utils Sample > Shader_Tap_Effect > UI_TapRippleEffect )

5.実行！